### PR TITLE
Feature/summary size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# unreleased
+# v1.8.0
 
-- Added: Smart summary truncation. It first checks whether the content looks like the full text (by using some length threshold) or a short synposis. In the latter case, no truncation will be applied.
+- Changed: Smart summary truncation. When there is no dedicated `summary` (Atom only) from the source, we check if the content/description (Both Atom and RSS) field is long enough to be full text. If so, it will be truncated into a "pseudo" summary. If not, we assume the source used the `content` field as summary, and it will be displayed in full length.
+- Thank you: @LooperXX.
 
 # v1.7.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Added: Smart summary truncation. It first checks whether the content looks like the full text (by using some length threshold) or a short synposis. In the latter case, no truncation will be applied.
+
 # v1.7.3
 
 - This release has no user facing changes. It is created for recording keeping and won't be published.

--- a/docs/osmosfeed-yaml-reference.md
+++ b/docs/osmosfeed-yaml-reference.md
@@ -4,19 +4,19 @@
 - `optional` properties contain **default** values.
 
 ```yaml
-# A URL that contains previous build output. (required)
+# `cacheUrl`: A URL that contains previous build output. (required)
 cacheUrl: https://<github_username>.github.io/<github_repo>/cache.json
 
-# An array of RSS subscriptions. (required)
+# `sources`: An array of RSS subscriptions. (required)
 sources:
-  # href: A URL that returns content in RSS 1.0, RSS 2.0, or Atom format. (required for each source)
+  # `href`: A URL that returns content in RSS 1.0, RSS 2.0, or Atom format. (required for each source)
   - href: https://example-website-1.com/feed/
   - href: https://example-website-2.com/feed/
   - href: https://example-website-3.com/feed/
 
-# Title to use in the browser tab and the machine readable feed output. (optional)
+# `siteTitle`: Title to use in the browser tab and the machine readable feed output. (optional)
 siteTitle: "osmos::feed"
 
-# Max number of days to keep the feed content in cache. A very large value can increase the initial load time of the site. (optional)
+# `cacheMaxDays` Max number of days to keep the feed content in cache. A very large value can increase the initial load time of the site. (optional)
 cacheMaxDays: 30
 ```

--- a/packages/cli/src/lib/enrich.ts
+++ b/packages/cli/src/lib/enrich.ts
@@ -2,18 +2,21 @@ import cheerio from "cheerio";
 import { performance } from "perf_hooks";
 import Parser from "rss-parser";
 import { downloadTextFile } from "../utils/download";
+import { getNonEmptyStringOrNull } from "../utils/ensure-string-content";
+import { getFirstNonNullItem } from "../utils/get-first-non-null-item";
 import { htmlToText } from "../utils/html-to-text";
+import { trimWithThreshold } from "../utils/trim-with-threshold";
 import type { Cache } from "./get-cache";
 import type { Config, Source } from "./get-config";
 
 const MILLISECONDS_PER_DAY = 86400000; // 1000 * 60 * 60 * 24
 const SUMMARY_TRIM_ACTIVATION_THRESHOLD = 2048; // characters
-const SUMMARY_TRIM_TO_LENGTH = 1024; // characters
+const SUMMARY_TRIM_TO_LENGTH = 800; // characters
 
 export interface EnrichedArticle {
   id: string;
   author: string | null;
-  description: string;
+  description: string; // TODO in next major release, use `summary` instead, so as to distinguish from `content`
   link: string;
   publishedOn: string;
   title: string;
@@ -63,9 +66,8 @@ async function enrichInternal(enrichInput: EnrichInput): Promise<EnrichedSource>
 
     if (!link) return null;
 
-    // TODO split into download, parse steps
     const enrichedItem = await enrichItem(link);
-    const description = item.contentSnippet ?? enrichedItem.description ?? "";
+    const description = getSummary({ parsedItem: item, enrichedItem: enrichedItem });
     const publishedOn = item.isoDate ?? enrichedItem.publishedTime?.toISOString() ?? new Date().toISOString();
     const id = item.guid ?? link;
     const author = item.creator ?? null;
@@ -164,38 +166,50 @@ async function enrichItem(link: string): Promise<EnrichItemResult> {
   }
 }
 
-function normalizeFeed(feed: Parser.Output<{}>): Parser.Output<{}> {
+interface ParsedFeed {
+  link: string | null;
+  title: string | null;
+  items: ParsedFeedItem[];
+}
+
+interface ParsedFeedItem {
+  guid: string | null;
+  title: string | null;
+  link: string | null;
+  isoDate: string | null;
+  creator: string | null;
+  summary: string | null;
+  content: string | null;
+}
+
+function normalizeFeed(feed: Parser.Output<{}>): ParsedFeed {
   return {
-    ...feed,
-    link: feed.link?.trim(),
-    title: feed.title?.trim(),
+    link: getNonEmptyStringOrNull(feed.link),
+    title: getNonEmptyStringOrNull(feed.title),
     items: feed.items.map((item) => ({
-      ...item,
-      guid: item.guid?.trim(),
-      title: item.title?.trim(),
-      link: item.link?.trim(),
-      creator: item.creator?.trim(),
-      contentSnippet: normalizeContentSnippet(item),
+      content: getNonEmptyStringOrNull(item.contentSnippet),
+      creator: getNonEmptyStringOrNull(item.creator),
+      guid: getNonEmptyStringOrNull(item.guid),
+      isoDate: getNonEmptyStringOrNull(item.isoDate),
+      link: getNonEmptyStringOrNull(item.link),
+      summary: getNonEmptyStringOrNull(item.summary),
+      title: getNonEmptyStringOrNull(item.title),
     })),
   };
 }
 
-function normalizeContentSnippet(item: Parser.Item): string | undefined {
-  /* We trust Atom feed authors not putting full text in the summary field */
-  if (item.summary?.trim()) return item.summary.trim();
-
-  /* When using the `content` fields, the author has an ambigous intention: it can be either full text or a synopsis. */
-  if (item.content?.trim())
-    return limitLength(htmlToText(item.content.trim()), SUMMARY_TRIM_ACTIVATION_THRESHOLD, SUMMARY_TRIM_TO_LENGTH);
-  if (item.contentSnippet?.trim())
-    return limitLength(
-      htmlToText(item.contentSnippet.trim()),
-      SUMMARY_TRIM_ACTIVATION_THRESHOLD,
-      SUMMARY_TRIM_TO_LENGTH
-    );
-  return;
+function getSummary(input: GetSummaryInput): string {
+  return getFirstNonNullItem(
+    input.parsedItem.summary,
+    input.parsedItem.content
+      ? trimWithThreshold(input.parsedItem.content, SUMMARY_TRIM_ACTIVATION_THRESHOLD, SUMMARY_TRIM_TO_LENGTH)
+      : null,
+    input.enrichedItem.description,
+    ""
+  );
 }
 
-function limitLength(input: string, activationThreshold: number, trimTo: number): string {
-  return input.length > activationThreshold ? `${input.slice(0, trimTo)}…` : input;
+interface GetSummaryInput {
+  parsedItem: ParsedFeedItem;
+  enrichedItem: EnrichItemResult;
 }

--- a/packages/cli/src/lib/get-config.ts
+++ b/packages/cli/src/lib/get-config.ts
@@ -14,9 +14,9 @@ export interface Config {
 
 export async function getConfig(configFile: ParsableFile | null): Promise<Config> {
   const userConfig = configFile ? parseUserConfig(configFile.rawText) : {};
-  const finalConfig = { ...getDefaultConfig(), ...userConfig };
-  console.log(`[load-config] Effective config: `, finalConfig);
-  return finalConfig;
+  const effectiveConfig = { ...getDefaultConfig(), ...userConfig };
+  console.log(`[load-config] Effective config: `, effectiveConfig);
+  return effectiveConfig;
 }
 
 function getDefaultConfig(): Config {

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import Handlebars from "handlebars";
 import { performance } from "perf_hooks";
 import { copyStatic } from "./lib/copy-static";
 import { discoverSystemFiles, discoverUserFiles } from "./lib/discover-files";

--- a/packages/cli/src/utils/ensure-string-content.ts
+++ b/packages/cli/src/utils/ensure-string-content.ts
@@ -1,0 +1,6 @@
+export function getNonEmptyStringOrNull(input?: string): string | null {
+  const trimmed = input?.trim();
+  if (!trimmed?.length) return null;
+
+  return trimmed;
+}

--- a/packages/cli/src/utils/get-first-non-null-item.ts
+++ b/packages/cli/src/utils/get-first-non-null-item.ts
@@ -1,0 +1,6 @@
+export function getFirstNonNullItem<T>(...args: (T | null)[]): T {
+  const nonNullString = args.find((item) => item !== null);
+  if (!nonNullString) throw new Error("At least one option must be a string");
+
+  return nonNullString;
+}

--- a/packages/cli/src/utils/trim-with-threshold.ts
+++ b/packages/cli/src/utils/trim-with-threshold.ts
@@ -1,0 +1,3 @@
+export function trimWithThreshold(input: string, activationThreshold: number, trimTo: number): string {
+  return input.length > activationThreshold ? `${input.slice(0, trimTo)}…` : input;
+}


### PR DESCRIPTION
- Changed: Smart summary truncation. When there is no dedicated `summary` (only Atom feed has it, and many sites don't use it) from the source, we check if the content or description field is long enough to be full text. If so, it will be truncated into a "pseudo" summary. If not, we assume the source used the `content` field as summary, and it will be displayed in full length.