### PR TITLE
Feature/itunes feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
-# unreleased
+# v1.9.0
 
 - Added: experimental support for podcast sources. You can render an audio control to play the mp3 file and display iTunes episode duration. Caveats:
-  - 1. iTunes has no strict format requirement for `duration`. The unit is most likely seconds. A future version may parse it automatically.
-  - 2. No image support yet. Some shows might have disabled CORS so osmosfeed must figure out a way to download the asset. A future version may support it.
-  - 2. You can't republish the podcast in the feed output. This is currently beyond the scope of the project though a future major update might make it possible.
+  - 1. This feature is currently only available through custom template.
+  - 2. iTunes has no strict format requirement for `duration`. The unit is most likely seconds. A future version may expose a human readable string to the template.
+  - 3. No image support yet. Some shows might have disabled CORS or use a relative URL for image, which forces osmosfeed to download the image during build. A future version may support it.
+  - 4. You can't republish the podcast in the feed output. Supporting this goes beyond the scope of the project at the moment.
 - Fixed: the `articles` in template data were not sorted.
 
 # v1.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# unreleased
+
+- Added: experimental support for podcast sources. You can render an audio control to play the mp3 file and display iTunes episode duration. Caveats:
+  - 1. iTunes has no strict format requirement for `duration`. The unit is most likely seconds. A future version may parse it automatically.
+  - 2. No image support yet. Some shows might have disabled CORS so osmosfeed must figure out a way to download the asset. A future version may support it.
+  - 2. You can't republish the podcast in the feed output. This is currently beyond the scope of the project though a future major update might make it possible.
+
 # v1.8.1
 
 - Fixed: `UnhandledPromiseRejectionWarning: Error: At least one option must be a string`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   - 1. iTunes has no strict format requirement for `duration`. The unit is most likely seconds. A future version may parse it automatically.
   - 2. No image support yet. Some shows might have disabled CORS so osmosfeed must figure out a way to download the asset. A future version may support it.
   - 2. You can't republish the podcast in the feed output. This is currently beyond the scope of the project though a future major update might make it possible.
+- Fixed: the `articles` in template data were not sorted.
 
 # v1.8.1
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -51,7 +51,7 @@ Currently no CI/CD integration. To publish a new version you must have permissio
 cd packages/cli
 
 # Choose one of the three
-npm version prerelease --preid=beta # starting a new beta
+npm version preminor --preid=beta # starting a new beta (use prepatch|preemajor as needed)
 npm version prerelease              # bumping up an existing beta
 npm version patch|minor|major       # update official release to new semver
 

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osmoscraft/osmosfeed",
-  "version": "1.8.1",
+  "version": "1.9.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@osmoscraft/osmosfeed",
-      "version": "1.8.1",
+      "version": "1.9.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@osmoscraft/osmosfeed",
-  "version": "1.9.0-beta.0",
+  "version": "1.9.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@osmoscraft/osmosfeed",
-      "version": "1.9.0-beta.0",
+      "version": "1.9.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.21.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osmoscraft/osmosfeed",
-  "version": "1.9.0-beta.0",
+  "version": "1.9.0-beta.1",
   "description": "",
   "scripts": {
     "dev": "node scripts/build.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osmoscraft/osmosfeed",
-  "version": "1.8.1",
+  "version": "1.9.0-beta.0",
   "description": "",
   "scripts": {
     "dev": "node scripts/build.js",

--- a/packages/cli/src/lib/enrich.ts
+++ b/packages/cli/src/lib/enrich.ts
@@ -74,8 +74,8 @@ async function enrichInternal(enrichInput: EnrichInput): Promise<EnrichedSource>
 
     if (!link) return null;
 
-    const enrichedItem = await enrichItem(link);
-    const description = getSummary({ parsedItem: item, enrichedItem: enrichedItem });
+    const enrichedItem = item.itunes ? unenrichableItem : await enrichItem(link);
+    const description = getSummary({ parsedItem: item, enrichedItem });
     const publishedOn = item.isoDate ?? enrichedItem.publishedTime?.toISOString() ?? new Date().toISOString();
     const id = item.guid ?? link;
     const author = item.creator ?? null;
@@ -165,16 +165,15 @@ async function enrichItem(link: string): Promise<EnrichItemResult> {
     return enrichItemResult;
   } catch (err) {
     console.log(`[enrich] Error enrich ${link}`);
-
-    const emptyResult: EnrichItemResult = {
-      description: null,
-      wordCount: null,
-      publishedTime: null,
-    };
-
-    return emptyResult;
+    return unenrichableItem;
   }
 }
+
+const unenrichableItem: EnrichItemResult = {
+  description: null,
+  wordCount: null,
+  publishedTime: null,
+};
 
 interface ParsedFeed {
   link: string | null;

--- a/packages/cli/src/lib/get-template-data.ts
+++ b/packages/cli/src/lib/get-template-data.ts
@@ -75,17 +75,18 @@ export function getTemplateData(input: GetTemplateDataInput): GetTemplateDataOut
 }
 
 function organizeByArticles(enrichedSources: EnrichedSource[]): TemplateArticle[] {
-  const articles: TemplateArticle[] = enrichedSources.flatMap((enrichedSource) =>
-    enrichedSource.articles.map((article) => ({
-      ...article,
-      source: enrichedSource,
-      isoPublishDate: article.publishedOn.split("T")[0],
-      title: ensureDisplayString(htmlToText(article.title), "Untitled"),
-      description: ensureDisplayString(htmlToText(article.description), "No content preview"),
-      readingTimeInMin: Math.round((article.wordCount ?? 0) / 300),
-    }))
-  );
-
+  const articles: TemplateArticle[] = enrichedSources
+    .flatMap((enrichedSource) =>
+      enrichedSource.articles.map((article) => ({
+        ...article,
+        source: enrichedSource,
+        isoPublishDate: article.publishedOn.split("T")[0],
+        title: ensureDisplayString(htmlToText(article.title), "Untitled"),
+        description: ensureDisplayString(htmlToText(article.description), "No content preview"),
+        readingTimeInMin: Math.round((article.wordCount ?? 0) / 300),
+      }))
+    )
+    .sort((a, b) => b.publishedOn.localeCompare(a.publishedOn)); // by time, most recent first
   return articles;
 }
 

--- a/packages/sandbox/osmosfeed.yaml
+++ b/packages/sandbox/osmosfeed.yaml
@@ -1,15 +1,5 @@
-# This config is used for local developement
-
-# cacheUrl: https://dailyread.netlify.app/cache.json
-# cacheMaxDays: 30
-# siteTitle: dev - osmosfeed
+# cacheUrl: https://GITHUB_USERNAME.github.io/REPO_NAME/cache.json
 sources:
-  - href: https://www.freecodecamp.org/news/rss/
-  - href: https://christianheilmann.com/feed/
-  - href: https://daverupert.com/atom.xml
-  - href: https://css-tricks.com/feed/
-  - href: https://developer.chrome.com/feeds/blog.xml
-  - href: https://webkit.org/feed/atom/
-  - href: https://hacks.mozilla.org/feed/
-  # - href: https://gomakethings.com/feed
-  # - href: https://feeds.npr.org/510289/podcast.xml
+  - href: https://feeds.npr.org/510289/podcast.xml
+  - href: https://shoptalkshow.com/feed/podcast/
+  - href: https://feed.syntax.fm/rss

--- a/packages/sandbox/osmosfeed.yaml
+++ b/packages/sandbox/osmosfeed.yaml
@@ -12,3 +12,4 @@ sources:
   - href: https://webkit.org/feed/atom/
   - href: https://hacks.mozilla.org/feed/
   # - href: https://gomakethings.com/feed
+  # - href: https://feeds.npr.org/510289/podcast.xml


### PR DESCRIPTION
- Added: experimental support for podcast sources. You can render an audio control to play the mp3 file and display iTunes episode duration. Caveats:
  - 1. This feature is currently only available through custom template.
  - 2. iTunes has no strict format requirement for `duration`. The unit is most likely seconds. A future version may expose a human readable string to the template.
  - 3. No image support yet. Some shows might have disabled CORS or use a relative URL for image, which forces osmosfeed to download the image during build. A future version may support it.
  - 4. You can't republish the podcast in the feed output. Supporting this goes beyond the scope of the project at the moment.
- Fixed: the `articles` in template data were not sorted.
