### PR TITLE
Filtering articles whose publishedOn is after today

### DIFF
--- a/packages/cli/src/lib/enrich.ts
+++ b/packages/cli/src/lib/enrich.ts
@@ -118,9 +118,10 @@ async function enrichInternal(enrichInput: EnrichInput): Promise<EnrichedSource 
   const combinedArticles = [...newArticles, ...cachedArticles];
 
   const renderedArticles = combinedArticles
-    .filter(
-      (item) => Math.round((now - new Date(item.publishedOn).getTime()) / MILLISECONDS_PER_DAY) < config.cacheMaxDays
-    )
+    .filter((item) => {
+      const elapsedDate = Math.round((now - new Date(item.publishedOn).getTime()) / MILLISECONDS_PER_DAY);
+      return elapsedDate < config.cacheMaxDays && elapsedDate >= 0;
+    })
     .sort((a, b) => b.publishedOn.localeCompare(a.publishedOn));
 
   const durationInSeconds = ((performance.now() - startTime) / 1000).toFixed(2);


### PR DESCRIPTION
There is a way to put a page like a table of contents at the top of the article list by setting "pubDate" to a future date. For example, [this](https://kougasetumei.hatenablog.com/rss) feed has a "pubDate" of `Fri, 31 Dec 9999 23:59:00 +0900`.

The current v1 code accepts all such articles, but this PR have changed it to reject them.

If this is not in line with your project policy, please feel free to close it.