### PR TITLE
V1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # v1.14.0
 
+- (planned): Add weekday display
+- (planned): Relative timestamp on each article, flush right align
+- (planned): Move reading time to bottom the content snippet
 - New: Card title now toggles card content. The link to feed source is available as standalone link.
+- New: all toggles on the UI are persisted with local storage
 - New: High-fidelity timestamp available as `isoLatestPublishTime` on all levels of template data
 - Changed: Sources are sorted based on publish time rather than alphabetical order
 - Fixed: Horizontal overflow on Safari

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v1.14.0
 
-- New: Adjust article grouping based on timezone. You need to add `timezone` in `osmosfeed.yml` for accurate grouping
+- New: Adjust article grouping based on timezone. You need to add `timezone` in `osmosfeed.yml` for accurate grouping. [See details in documentation](./docs/osmosfeed-yaml-reference.md).
 - New: Card title now toggles card content
 - New: all toggles on the UI are persisted with local storage. You can use it to track read/unread status within a single browser.
 - New: Build timestamp now links to the GitHub Action run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
 # v1.14.0
 
-- (planned): Add weekday display
-- (planned): Relative timestamp on each article, flush right align
-- (planned): Move reading time to bottom the content snippet
-- (planned): Merge all cards on a single into a grid
-- New: Card title now toggles card content. The link to feed source is available as standalone link.
-- New: all toggles on the UI are persisted with local storage
-- New: High-fidelity timestamp available as `isoLatestPublishTime` on all levels of template data
+- New: Adjust article grouping based on timezone. You need to add `timezone` in `osmosfeed.yml` for accurate grouping
+- New: Card title now toggles card content
+- New: all toggles on the UI are persisted with local storage. You can use it to track read/unread status within a single browser.
 - Changed: Sources are sorted based on publish time rather than alphabetical order
+- Changed: Style updates for higher information density
 - Fixed: Horizontal overflow on Safari
 - Fixed: HTML syntax error in default template
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - (planned): Add weekday display
 - (planned): Relative timestamp on each article, flush right align
 - (planned): Move reading time to bottom the content snippet
+- (planned): Merge all cards on a single into a grid
 - New: Card title now toggles card content. The link to feed source is available as standalone link.
 - New: all toggles on the UI are persisted with local storage
 - New: High-fidelity timestamp available as `isoLatestPublishTime` on all levels of template data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - New: Adjust article grouping based on timezone. You need to add `timezone` in `osmosfeed.yml` for accurate grouping
 - New: Card title now toggles card content
 - New: all toggles on the UI are persisted with local storage. You can use it to track read/unread status within a single browser.
+- New: Build timestamp now links to the GitHub Action run
 - Changed: Sources are sorted based on publish time rather than alphabetical order
 - Changed: Style updates for higher information density
 - Fixed: Horizontal overflow on Safari

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - New: all toggles on the UI are persisted with local storage. You can use it to track read/unread status within a single browser.
 - New: Build timestamp now links to the GitHub Action run
 - Changed: Sources are sorted based on publish time rather than alphabetical order
-- Changed: Style updates for higher information density
+- Changed: Style adjusted for easier reading
 - Fixed: Horizontal overflow on Safari
 - Fixed: HTML syntax error in default template
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.14.0
+
+- New: Card title now toggles card content. The link to feed source is available as standalone link.
+- New: High-fidelity timestamp available as `isoLatestPublishTime` on all levels of template data
+- Changed: Sources are sorted based on publish time rather than alphabetical order
+- Fixed: Horizontal overflow on Safari
+- Fixed: HTML syntax error in default template
+
 # v1.13.0
 
 - New: Thumbnail image display for each article

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Browse all [sources and more examples](https://github.com/osmoscraft/osmosfeed-e
 
    ```yaml
    cacheUrl: https://<github_username>.github.io/<repo>/cache.json
-   timezone: America/Los_Angeles
    sources:
      - href: https://my-rss-source-1/feed/
      - href: https://my-rss-source-2/rss/

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ An RSS reader running entirely from your GitHub repo.
 [![image](https://user-images.githubusercontent.com/1895289/114334657-e4268600-9aff-11eb-90c6-184284b90be2.png)](https://osmoscraft.github.io/osmosfeed-demo/)
 
 ### More examples
+
 - 💻 [Default template + Gruvbox dark](https://osmoscraft.github.io/osmosfeed-demo/) | [View source](https://github.com/osmoscraft/osmosfeed-demo)
 - 😎 [Default template + Solarized dark](https://osmoscraft.github.io/osmosfeed-examples/default-solarized-dark/)
 - ☀ [Default template + Solarized light](https://osmoscraft.github.io/osmosfeed-examples/default-solarized-light/)
 - ❄ [Custom template + Nord dark](https://onnyyonn.github.io/feed/) | [View source](https://github.com/onnyyonn/feed) | by [onnyyonn](https://github.com/onnyyonn)
-- 🔨 [Unstyled template](https://osmoscraft.github.io/osmosfeed-examples/articles-unstyled/) for building from scratch.  
+- 🔨 [Unstyled template](https://osmoscraft.github.io/osmosfeed-examples/articles-unstyled/) for building from scratch.
 - 📺 [YouTube feed template + Material dark](https://osmoscraft.github.io/osmosfeed-examples/youtube-dark/)
 - 🎧 [Unstyled template for building a podcast feed](https://osmoscraft.github.io/osmosfeed-examples/podcast-unstyled/)
-
 
 Browse all [sources and more examples](https://github.com/osmoscraft/osmosfeed-examples)
 
@@ -53,6 +53,7 @@ Browse all [sources and more examples](https://github.com/osmoscraft/osmosfeed-e
 
    ```yaml
    cacheUrl: https://<github_username>.github.io/<repo>/cache.json
+   timezone: America/Los_Angeles
    sources:
      - href: https://my-rss-source-1/feed/
      - href: https://my-rss-source-2/rss/

--- a/README_zh.md
+++ b/README_zh.md
@@ -49,7 +49,6 @@
 
    ```yaml
    cacheUrl: https://<github_username>.github.io/<repo>/cache.json
-   timezone: Asia/Shanghai
    sources:
      - href: https://my-rss-source-1/feed/
      - href: https://my-rss-source-2/rss/

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,12 +4,12 @@
 
 # 奥斯莫::源系统
 
-利用GitHub搭建个人RSS阅读器
+利用 GitHub 搭建个人 RSS 阅读器
 
-- 利用[GitHub Pages](https://pages.github.com/)实现Hosting
+- 利用[GitHub Pages](https://pages.github.com/)实现 Hosting
 - 利用[GitHub Actions](https://github.com/features/actions)实现内容定期自动更新
-- 前端由Node.js静态生成
-- 使用Handlebars模板和CSS自定义变量实现主题自定义
+- 前端由 Node.js 静态生成
+- 使用 Handlebars 模板和 CSS 自定义变量实现主题自定义
 - 开源，免费，无第三方追踪
 
 ## 展示
@@ -27,28 +27,29 @@
 
 ### 创建新仓库
 
-1. [使用osmosfeed-template官方模板创建仓库](https://github.com/osmoscraft/osmosfeed-template/generate)
-2. 将可见性设为Public（公共）。  
+1. [使用 osmosfeed-template 官方模板创建仓库](https://github.com/osmoscraft/osmosfeed-template/generate)
+2. 将可见性设为 Public（公共）。  
    ![image](https://user-images.githubusercontent.com/1895289/118917672-3d938900-b8e6-11eb-892c-6bb9203c7419.png)
-3. 单击Create repository from template（从模板创建仓库）
+3. 单击 Create repository from template（从模板创建仓库）
 
-### 部署GitHub Pages
+### 部署 GitHub Pages
 
-1. 打开刚才创建的仓库，在仓库名称下，单击Settings（设置）, 在左侧边栏中，单击Pages（页面）
-2. 在“GitHub Pages”下，使用 None（无）下拉菜单选择发布源。选择 `gh-pages`, 单击 Save（保存）。如果在初次访问该页面的时候`gh-pages`并不存在，等待1－2分钟，刷新之后选项便会出现。  
+1. 打开刚才创建的仓库，在仓库名称下，单击 Settings（设置）, 在左侧边栏中，单击 Pages（页面）
+2. 在“GitHub Pages”下，使用 None（无）下拉菜单选择发布源。选择 `gh-pages`, 单击 Save（保存）。如果在初次访问该页面的时候`gh-pages`并不存在，等待 1－2 分钟，刷新之后选项便会出现。  
    ![image](https://user-images.githubusercontent.com/1895289/114324508-3dca8880-9adf-11eb-98c9-0a0779f5fd7a.png)
 
-3. 刷新页面，直到界面上出现 `Your site is published at https://<github_username>.github.io/<repo>`的确认信息（最多等待1－3分钟）即可离开。部署就此成功。  
+3. 刷新页面，直到界面上出现 `Your site is published at https://<github_username>.github.io/<repo>`的确认信息（最多等待 1－3 分钟）即可离开。部署就此成功。  
    ![image](https://user-images.githubusercontent.com/1895289/114324153-75383580-9add-11eb-81a6-186cb18d0851.png)
 
 ### 配置订阅
 
-1. 进入仓库的根目录，打开`osmosfeed.yaml`文件, 单击有铅笔图标的Edit this file（编辑此文件）按钮。
-2. 删除 `# ` 从而取消`cacheUrl`一行的注释。将`<github_username>`替换为GitHub用户名，将`<repo>`替换为仓库名.
-3. 在`sources:`(订阅源)下，添加你想要的RSS/Atom源。
+1. 进入仓库的根目录，打开`osmosfeed.yaml`文件, 单击有铅笔图标的 Edit this file（编辑此文件）按钮。
+2. 删除 `# ` 从而取消`cacheUrl`一行的注释。将`<github_username>`替换为 GitHub 用户名，将`<repo>`替换为仓库名.
+3. 在`sources:`(订阅源)下，添加你想要的 RSS/Atom 源。
 
    ```yaml
    cacheUrl: https://<github_username>.github.io/<repo>/cache.json
+   timezone: Asia/Shanghai
    sources:
      - href: https://my-rss-source-1/feed/
      - href: https://my-rss-source-2/rss/
@@ -57,15 +58,15 @@
      - href: https://my-rss-source-5/rss/
    ```
 
-4. 单击页面底部的Commit changes（提交更改）按钮。
-5. 等待前端自动静态生成（1－3分钟）。阅读器将在`https://<github_username>.github.io/<repo>`接受访问。
+4. 单击页面底部的 Commit changes（提交更改）按钮。
+5. 等待前端自动静态生成（1－3 分钟）。阅读器将在`https://<github_username>.github.io/<repo>`接受访问。
 
 ## 指南与参考
 
 - [自定义指南（英文）](./docs/customization-guide.md)
   - 更换皮肤
   - 更换模板
-  - 添加内联HTML, CSS, JavaScript
+  - 添加内联 HTML, CSS, JavaScript
   - 添加静态拷贝文件
 - [设置参考（英文）](./docs/osmosfeed-yaml-reference.md)
 - [源生成指南（英文）](./docs/headless-usage-guide.md)
@@ -79,15 +80,15 @@
 
 ### 可以更加频繁的更新内容吗？
 
-> 可以。更新频率没有特定限制。只需在工作流程设置文件`.github/workflows/update-feed.yaml`中改变[cron schedule](https://docs.github.com/cn/actions/reference/events-that-trigger-workflows)。但不要太贪心哟。GitHub对于每月工作流程运行的总时间有[限制](https://docs.github.com/cn/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions/about-billing-for-github-actions)。我掐指算了算，即便是每小时更新一次，每月将仍有不少分钟数盈余。你可以在[设置界面](https://github.com/settings/billing)随时查看本月剩余分钟数。
+> 可以。更新频率没有特定限制。只需在工作流程设置文件`.github/workflows/update-feed.yaml`中改变[cron schedule](https://docs.github.com/cn/actions/reference/events-that-trigger-workflows)。但不要太贪心哟。GitHub 对于每月工作流程运行的总时间有[限制](https://docs.github.com/cn/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions/about-billing-for-github-actions)。我掐指算了算，即便是每小时更新一次，每月将仍有不少分钟数盈余。你可以在[设置界面](https://github.com/settings/billing)随时查看本月剩余分钟数。
 
-### 我可以将仓库可见性设为Private（私人）吗？
+### 我可以将仓库可见性设为 Private（私人）吗？
 
-> 目前GitHub Pages建站暂不兼容私人仓库。如果你将静态生成的网站部署到其它虚拟主机或者存储服务器上的话，他们可能会提供密码保护。
+> 目前 GitHub Pages 建站暂不兼容私人仓库。如果你将静态生成的网站部署到其它虚拟主机或者存储服务器上的话，他们可能会提供密码保护。
 
-### 我在部署GitHub Pages之后访问阅读器，等到了海枯石烂也只能看到404。
+### 我在部署 GitHub Pages 之后访问阅读器，等到了海枯石烂也只能看到 404。
 
-> 在地址后加上`index.html`试试看？比如`https://<github_username>.github.io/<repo>／index.html`。GitHub有已知缺陷，详见[社区讨论](https://github.community/t/my-github-page-doesnt-redirect-to-index-html/10367/24)和[Stack Overflow上的解决方案](https://stackoverflow.com/questions/45362628/github-pages-site-not-detecting-index-html)。笔者亲测，随便提交一些空白的更新，重新触发工作流程便可解决问题。
+> 在地址后加上`index.html`试试看？比如`https://<github_username>.github.io/<repo>／index.html`。GitHub 有已知缺陷，详见[社区讨论](https://github.community/t/my-github-page-doesnt-redirect-to-index-html/10367/24)和[Stack Overflow 上的解决方案](https://stackoverflow.com/questions/45362628/github-pages-site-not-detecting-index-html)。笔者亲测，随便提交一些空白的更新，重新触发工作流程便可解决问题。
 
 ### 如何手动触发内容更新？
 
@@ -95,13 +96,13 @@
 
 ### 如何清空内容缓存？
 
-> 进入GitHub仓库里的`gh-pages`分支，（地址`https://github.com/<owner>/<repo>/tree/gh-pages`）。手动删除`cache.json`文件。触发一次内容更新即可。
+> 进入 GitHub 仓库里的`gh-pages`分支，（地址`https://github.com/<owner>/<repo>/tree/gh-pages`）。手动删除`cache.json`文件。触发一次内容更新即可。
 
 ## 生态系统
 
 奥斯莫::源系统是[奥斯莫::工艺系统](https://osmoscraft.org)的一员。如果你觉得这个工具好用，不妨认识一下它的“朋友”？
 
 - [奥斯莫::浏览器书签](https://github.com/osmoscraft/osmosmemo): 能够快速创建和搜索的浏览器书签。
-- [奥斯莫::知识笔记](https://github.com/osmoscraft/osmosnote): 以Git作为存储媒介，支持双向超链接的文本编辑器。
+- [奥斯莫::知识笔记](https://github.com/osmoscraft/osmosnote): 以 Git 作为存储媒介，支持双向超链接的文本编辑器。
 
 （翻译若有不妥请多多见谅。欢迎提供修改意见。如有疑问或想贡献文档翻译，请在[Disucssion](https://github.com/osmoscraft/osmosfeed/discussions/categories/ideas)创建新话题。谢谢。）

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,12 +4,12 @@
 
 # 奥斯莫::源系统
 
-利用 GitHub 搭建个人 RSS 阅读器
+利用GitHub搭建个人RSS阅读器
 
-- 利用[GitHub Pages](https://pages.github.com/)实现 Hosting
+- 利用[GitHub Pages](https://pages.github.com/)实现Hosting
 - 利用[GitHub Actions](https://github.com/features/actions)实现内容定期自动更新
-- 前端由 Node.js 静态生成
-- 使用 Handlebars 模板和 CSS 自定义变量实现主题自定义
+- 前端由Node.js静态生成
+- 使用Handlebars模板和CSS自定义变量实现主题自定义
 - 开源，免费，无第三方追踪
 
 ## 展示
@@ -26,25 +26,25 @@
 
 ### 创建新仓库
 
-1. [使用 osmosfeed-template 官方模板创建仓库](https://github.com/osmoscraft/osmosfeed-template/generate)
-2. 将可见性设为 Public（公共）。  
+1. [使用osmosfeed-template官方模板创建仓库](https://github.com/osmoscraft/osmosfeed-template/generate)
+2. 将可见性设为Public（公共）。  
    ![image](https://user-images.githubusercontent.com/1895289/118917672-3d938900-b8e6-11eb-892c-6bb9203c7419.png)
-3. 单击 Create repository from template（从模板创建仓库）
+3. 单击Create repository from template（从模板创建仓库）
 
-### 部署 GitHub Pages
+### 部署GitHub Pages
 
-1. 打开刚才创建的仓库，在仓库名称下，单击 Settings（设置）, 在左侧边栏中，单击 Pages（页面）
-2. 在“GitHub Pages”下，使用 None（无）下拉菜单选择发布源。选择 `gh-pages`, 单击 Save（保存）。如果在初次访问该页面的时候`gh-pages`并不存在，等待 1－2 分钟，刷新之后选项便会出现。  
+1. 打开刚才创建的仓库，在仓库名称下，单击Settings（设置）, 在左侧边栏中，单击Pages（页面）
+2. 在“GitHub Pages”下，使用 None（无）下拉菜单选择发布源。选择 `gh-pages`, 单击 Save（保存）。如果在初次访问该页面的时候`gh-pages`并不存在，等待1－2分钟，刷新之后选项便会出现。  
    ![image](https://user-images.githubusercontent.com/1895289/114324508-3dca8880-9adf-11eb-98c9-0a0779f5fd7a.png)
 
-3. 刷新页面，直到界面上出现 `Your site is published at https://<github_username>.github.io/<repo>`的确认信息（最多等待 1－3 分钟）即可离开。部署就此成功。  
+3. 刷新页面，直到界面上出现 `Your site is published at https://<github_username>.github.io/<repo>`的确认信息（最多等待1－3分钟）即可离开。部署就此成功。  
    ![image](https://user-images.githubusercontent.com/1895289/114324153-75383580-9add-11eb-81a6-186cb18d0851.png)
 
 ### 配置订阅
 
-1. 进入仓库的根目录，打开`osmosfeed.yaml`文件, 单击有铅笔图标的 Edit this file（编辑此文件）按钮。
-2. 删除 `# ` 从而取消`cacheUrl`一行的注释。将`<github_username>`替换为 GitHub 用户名，将`<repo>`替换为仓库名.
-3. 在`sources:`(订阅源)下，添加你想要的 RSS/Atom 源。
+1. 进入仓库的根目录，打开`osmosfeed.yaml`文件, 单击有铅笔图标的Edit this file（编辑此文件）按钮。
+2. 删除 `# ` 从而取消`cacheUrl`一行的注释。将`<github_username>`替换为GitHub用户名，将`<repo>`替换为仓库名.
+3. 在`sources:`(订阅源)下，添加你想要的RSS/Atom源。
 
    ```yaml
    cacheUrl: https://<github_username>.github.io/<repo>/cache.json
@@ -56,15 +56,15 @@
      - href: https://my-rss-source-5/rss/
    ```
 
-4. 单击页面底部的 Commit changes（提交更改）按钮。
-5. 等待前端自动静态生成（1－3 分钟）。阅读器将在`https://<github_username>.github.io/<repo>`接受访问。
+4. 单击页面底部的Commit changes（提交更改）按钮。
+5. 等待前端自动静态生成（1－3分钟）。阅读器将在`https://<github_username>.github.io/<repo>`接受访问。
 
 ## 指南与参考
 
 - [自定义指南（英文）](./docs/customization-guide.md)
   - 更换皮肤
   - 更换模板
-  - 添加内联 HTML, CSS, JavaScript
+  - 添加内联HTML, CSS, JavaScript
   - 添加静态拷贝文件
 - [设置参考（英文）](./docs/osmosfeed-yaml-reference.md)
 - [源生成指南（英文）](./docs/headless-usage-guide.md)
@@ -78,15 +78,15 @@
 
 ### 可以更加频繁的更新内容吗？
 
-> 可以。更新频率没有特定限制。只需在工作流程设置文件`.github/workflows/update-feed.yaml`中改变[cron schedule](https://docs.github.com/cn/actions/reference/events-that-trigger-workflows)。但不要太贪心哟。GitHub 对于每月工作流程运行的总时间有[限制](https://docs.github.com/cn/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions/about-billing-for-github-actions)。我掐指算了算，即便是每小时更新一次，每月将仍有不少分钟数盈余。你可以在[设置界面](https://github.com/settings/billing)随时查看本月剩余分钟数。
+> 可以。更新频率没有特定限制。只需在工作流程设置文件`.github/workflows/update-feed.yaml`中改变[cron schedule](https://docs.github.com/cn/actions/reference/events-that-trigger-workflows)。但不要太贪心哟。GitHub对于每月工作流程运行的总时间有[限制](https://docs.github.com/cn/github/setting-up-and-managing-billing-and-payments-on-github/managing-billing-for-github-actions/about-billing-for-github-actions)。我掐指算了算，即便是每小时更新一次，每月将仍有不少分钟数盈余。你可以在[设置界面](https://github.com/settings/billing)随时查看本月剩余分钟数。
 
-### 我可以将仓库可见性设为 Private（私人）吗？
+### 我可以将仓库可见性设为Private（私人）吗？
 
-> 目前 GitHub Pages 建站暂不兼容私人仓库。如果你将静态生成的网站部署到其它虚拟主机或者存储服务器上的话，他们可能会提供密码保护。
+> 目前GitHub Pages建站暂不兼容私人仓库。如果你将静态生成的网站部署到其它虚拟主机或者存储服务器上的话，他们可能会提供密码保护。
 
-### 我在部署 GitHub Pages 之后访问阅读器，等到了海枯石烂也只能看到 404。
+### 我在部署GitHub Pages之后访问阅读器，等到了海枯石烂也只能看到404。
 
-> 在地址后加上`index.html`试试看？比如`https://<github_username>.github.io/<repo>／index.html`。GitHub 有已知缺陷，详见[社区讨论](https://github.community/t/my-github-page-doesnt-redirect-to-index-html/10367/24)和[Stack Overflow 上的解决方案](https://stackoverflow.com/questions/45362628/github-pages-site-not-detecting-index-html)。笔者亲测，随便提交一些空白的更新，重新触发工作流程便可解决问题。
+> 在地址后加上`index.html`试试看？比如`https://<github_username>.github.io/<repo>／index.html`。GitHub有已知缺陷，详见[社区讨论](https://github.community/t/my-github-page-doesnt-redirect-to-index-html/10367/24)和[Stack Overflow上的解决方案](https://stackoverflow.com/questions/45362628/github-pages-site-not-detecting-index-html)。笔者亲测，随便提交一些空白的更新，重新触发工作流程便可解决问题。
 
 ### 如何手动触发内容更新？
 
@@ -94,13 +94,13 @@
 
 ### 如何清空内容缓存？
 
-> 进入 GitHub 仓库里的`gh-pages`分支，（地址`https://github.com/<owner>/<repo>/tree/gh-pages`）。手动删除`cache.json`文件。触发一次内容更新即可。
+> 进入GitHub仓库里的`gh-pages`分支，（地址`https://github.com/<owner>/<repo>/tree/gh-pages`）。手动删除`cache.json`文件。触发一次内容更新即可。
 
 ## 生态系统
 
 奥斯莫::源系统是[奥斯莫::工艺系统](https://osmoscraft.org)的一员。如果你觉得这个工具好用，不妨认识一下它的“朋友”？
 
 - [奥斯莫::浏览器书签](https://github.com/osmoscraft/osmosmemo): 能够快速创建和搜索的浏览器书签。
-- [奥斯莫::知识笔记](https://github.com/osmoscraft/osmosnote): 以 Git 作为存储媒介，支持双向超链接的文本编辑器。
+- [奥斯莫::知识笔记](https://github.com/osmoscraft/osmosnote): 以Git作为存储媒介，支持双向超链接的文本编辑器。
 
 （翻译若有不妥请多多见谅。欢迎提供修改意见。如有疑问或想贡献文档翻译，请在[Disucssion](https://github.com/osmoscraft/osmosfeed/discussions/categories/ideas)创建新话题。谢谢。）

--- a/docs/osmosfeed-yaml-reference.md
+++ b/docs/osmosfeed-yaml-reference.md
@@ -17,8 +17,8 @@ sources:
 # `siteTitle`: Title to use in the browser tab and the machine readable feed output. (optional)
 siteTitle: "osmos::feed"
 
-# `timezone`: Match server timezone with your browser's timezone so content can be grouped correctly.
-# Find yours from https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# `timezone`: Specify your local timezone so server can group content by weekday
+# Find yours from the "TZ database name" column of this page: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List
 # Examples: America/Los_Angeles, America/New_York, Asia/Shanghai, Asia/Tokyo
 timezone: null
 

--- a/docs/osmosfeed-yaml-reference.md
+++ b/docs/osmosfeed-yaml-reference.md
@@ -17,6 +17,11 @@ sources:
 # `siteTitle`: Title to use in the browser tab and the machine readable feed output. (optional)
 siteTitle: "osmos::feed"
 
+# `timezone`: Match server timezone with your browser's timezone so content can be grouped correctly.
+# Find yours from https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# Examples: America/Los_Angeles, America/New_York, Asia/Shanghai, Asia/Tokyo
+timezone: null
+
 # `cacheMaxDays` Max number of days to keep the feed content in cache. A very large value can increase the initial load time of the site. (optional)
 cacheMaxDays: 30
 ```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osmoscraft/osmosfeed",
-  "version": "1.13.0",
+  "version": "1.14.0-beta.0",
   "description": "",
   "scripts": {
     "dev": "node scripts/build.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osmoscraft/osmosfeed",
-  "version": "1.14.0-beta.0",
+  "version": "1.14.0",
   "description": "",
   "scripts": {
     "dev": "node scripts/build.js",

--- a/packages/cli/src/lib/__tests__/time.test.ts
+++ b/packages/cli/src/lib/__tests__/time.test.ts
@@ -4,10 +4,11 @@ import { getOffsetFromTimezoneName } from "../time";
 describe("getOffsetFromTimezoneName", () => {
   it("handles url that doesn't need encoding", () => {
     // Note that the symbol is inverted from international convention
-    expect(getOffsetFromTimezoneName("Asia/Shanghai")).toBe(-480); // +8
-    expect(getOffsetFromTimezoneName("Asia/Tokyo")).toBe(-540); // +9
+    // Source: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    expect(getOffsetFromTimezoneName("Asia/Shanghai")).toBe(-480); // GMT+8
+    expect(getOffsetFromTimezoneName("Asia/Tokyo")).toBe(-540); // GMT+9
     expect(getOffsetFromTimezoneName("UTC")).toBe(0);
-    expect(getOffsetFromTimezoneName("EST")).toBe(300);
-    expect(getOffsetFromTimezoneName("Pacific/Honolulu")).toBe(600);
+    expect(getOffsetFromTimezoneName("EST")).toBe(300); // GMT-5
+    expect(getOffsetFromTimezoneName("Pacific/Honolulu")).toBe(600); //GMT-10
   });
 });

--- a/packages/cli/src/lib/__tests__/time.test.ts
+++ b/packages/cli/src/lib/__tests__/time.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { getOffsetFromTimezoneName } from "../time";
+
+describe("getOffsetFromTimezoneName", () => {
+  it("handles url that doesn't need encoding", () => {
+    // Note that the symbol is inverted from international convention
+    expect(getOffsetFromTimezoneName("Asia/Shanghai")).toBe(-480); // +8
+    expect(getOffsetFromTimezoneName("Asia/Tokyo")).toBe(-540); // +9
+    expect(getOffsetFromTimezoneName("UTC")).toBe(0);
+    expect(getOffsetFromTimezoneName("EST")).toBe(300);
+    expect(getOffsetFromTimezoneName("Pacific/Honolulu")).toBe(600);
+  });
+});

--- a/packages/cli/src/lib/get-config.ts
+++ b/packages/cli/src/lib/get-config.ts
@@ -1,6 +1,7 @@
-import type { ParsableFile } from "./discover-files";
 import yaml from "js-yaml";
+import type { ParsableFile } from "./discover-files";
 import { normalizeUrl } from "./normalize-url";
+import { getOffsetFromTimezoneName } from "./time";
 
 export interface Source {
   href: string;
@@ -11,6 +12,8 @@ export interface Config {
   cacheUrl: string | null;
   cacheMaxDays: number;
   siteTitle: string;
+  timezone: string | null;
+  timezoneOffset: number;
 }
 
 export async function getConfig(configFile: ParsableFile | null): Promise<Config> {
@@ -22,6 +25,7 @@ export async function getConfig(configFile: ParsableFile | null): Promise<Config
       ...source,
       href: normalizeUrl(source.href),
     })),
+    timezoneOffset: mergedConfig.timezone ? getOffsetFromTimezoneName(mergedConfig.timezone) : 0,
   };
   console.log(`[load-config] Effective config: `, effectiveConfig);
   return effectiveConfig;
@@ -33,6 +37,8 @@ function getDefaultConfig(): Config {
     cacheUrl: null,
     cacheMaxDays: 30,
     siteTitle: "osmos::feed",
+    timezone: null,
+    timezoneOffset: 0,
   };
 }
 

--- a/packages/cli/src/lib/get-config.ts
+++ b/packages/cli/src/lib/get-config.ts
@@ -14,6 +14,9 @@ export interface Config {
   siteTitle: string;
   timezone: string | null;
   timezoneOffset: number;
+  githubServerUrl: string | null;
+  githubRepository: string | null;
+  githubRunId: string | null;
 }
 
 export async function getConfig(configFile: ParsableFile | null): Promise<Config> {
@@ -39,6 +42,9 @@ function getDefaultConfig(): Config {
     siteTitle: "osmos::feed",
     timezone: null,
     timezoneOffset: 0,
+    githubServerUrl: process.env.GITHUB_SERVER_URL ?? null,
+    githubRepository: process.env.GITHUB_REPOSITORY ?? null,
+    githubRunId: process.env.GITHUB_RUN_ID ?? null,
   };
 }
 

--- a/packages/cli/src/lib/get-template-data.ts
+++ b/packages/cli/src/lib/get-template-data.ts
@@ -62,7 +62,7 @@ interface TemplateSource extends TemplateSourceBase {
 interface TemplateDates {
   /**
    * @deprecated This date should only be used by the server internally.
-   * Use `isoUtcPublishTime` for high-fidelity timestamp or `isoOffsetPublishDate` for grouping by dates
+   * Use `isoUtcPublishTime` for true timestamp or `isoOffsetPublishDate` for grouping by dates
    */
   isoPublishDate: string;
   isoOffsetPublishDate: string;

--- a/packages/cli/src/lib/get-template-data.ts
+++ b/packages/cli/src/lib/get-template-data.ts
@@ -22,6 +22,9 @@ export interface GetTemplateDataOutput {
   /** ISO timestamp for the build */
   siteBuildTimestamp: string;
 
+  /** URL to the GitHub Action run. Available only when using GitHub Action */
+  githubRunUrl: string | null;
+
   siteTitle: string;
 }
 
@@ -80,6 +83,12 @@ export interface GetTemplateDataInput {
 }
 
 export function getTemplateData(input: GetTemplateDataInput): GetTemplateDataOutput {
+  const { githubServerUrl, githubRepository, githubRunId } = input.config;
+  const githubRunUrl =
+    githubServerUrl && githubRepository && githubRunId
+      ? `${input.config.githubServerUrl}/${input.config.githubRepository}/actions/run/${input.config.githubRunId}`
+      : null;
+
   return {
     get dates() {
       return organizeByDates(input);
@@ -94,6 +103,7 @@ export function getTemplateData(input: GetTemplateDataInput): GetTemplateDataOut
     },
 
     cliVersion,
+    githubRunUrl,
     siteTitle: input.config.siteTitle,
     siteBuildTimestamp: new Date().toISOString(),
     projectUrl: `https://github.com/osmoscraft/osmosfeed`,

--- a/packages/cli/src/lib/time.ts
+++ b/packages/cli/src/lib/time.ts
@@ -1,0 +1,24 @@
+const MINUTES_PER_MS = 1000 * 60;
+
+export function getTimeWithOffset(baseTimestamp: number, offsetInMinutes: number) {
+  return baseTimestamp - offsetInMinutes * 60 * 1000;
+}
+
+export function getDateFromIsoString(isoTimeString: string): string {
+  return isoTimeString.split("T")[0];
+}
+
+export function getIsoTimeWithOffset(utcIsoString: string, offsetInMinutes: number): string {
+  const date = new Date(utcIsoString);
+  const offsetTime = getTimeWithOffset(date.getTime(), offsetInMinutes);
+  const isoStirng = new Date(offsetTime).toISOString();
+
+  return isoStirng;
+}
+
+export function getOffsetFromTimezoneName(timezone: string) {
+  return (
+    Math.floor(new Date(new Date().toLocaleString("sv", { timeZone: "UTC" })).getTime() / MINUTES_PER_MS) -
+    Math.floor(new Date(new Date().toLocaleString("sv", { timeZone: timezone })).getTime() / MINUTES_PER_MS)
+  );
+}

--- a/packages/cli/src/system-static/index.css
+++ b/packages/cli/src/system-static/index.css
@@ -29,7 +29,7 @@
   --font-size-scaler: 62.5%; /* 1rem = 10px */
   --font-size-L: 3.6rem;
   --font-size-m: 2.2rem;
-  --font-size-s: 1.6rem;
+  --font-size-s: 1.8rem;
   --body-line-height: 1.4;
   --heading-line-height: 1.2;
 
@@ -41,33 +41,22 @@
   --body-padding: 32px 24px;
   --body-stack-gap: 32px;
 
-  --daily-heading-color: var(--base03);
-  --daily-heading-hover-color: var(--base04);
-
-  --source-name-color: var(--base05);
-  --source-name-hover-color: var(--base07);
-  --source-link-color: var(--base04);
-  --source-link-hover-color: var(--base07);
+  --accordion-content-rail-color: var(--base03);
+  --accordion-content-hover-rail-color: var(--base04);
+  --accordion-marker-color: var(--base0E);
+  --accordion-marker-hover-color: var(--base0E);
+  --accordion-marker-expanded-color: var(--base03);
+  --accordion-rail-indent: 7px;
 
   --article-stack-gap: 16px;
-
-  --article-title-color: var(--base09);
-  --article-title-hover-color: var(--base09);
-
-  --article-summary-color: var(--base04);
+  --article-title-color: var(--base0E);
+  --article-title-expanded-color: var(--base0E);
+  --article-summary-color: var(--base05);
   --article-summary-hover-color: var(--base07);
-
   --article-reading-time-color: var(--base04);
-
   --article-image-radius: 6px;
   --article-image-border-color: var(--base03);
   --article-image-shadow: none;
-
-  --accordion-content-rail-color: var(--base03);
-  --accordion-content-hover-rail-color: var(--base04);
-  --accordion-title-marker-color: var(--base03);
-  --accordion-title-hover-marker-color: var(--base04);
-  --accordion-rail-indent: 7px;
 
   --card-border-color: var(--base03);
   --card-bg: var(--base01);
@@ -75,8 +64,16 @@
   --card-stack-gap: 24px;
   --card-shadow: none;
 
+  --daily-heading-color: var(--base03);
+  --daily-heading-hover-color: var(--base04);
+
   --footer-color: var(--base04);
   --footer-link-hover-color: var(--base07);
+
+  --source-name-color: var(--base0A);
+  --source-name-hover-color: var(--base07);
+  --source-link-color: var(--base04);
+  --source-link-hover-color: var(--base07);
 }
 
 /**
@@ -90,6 +87,18 @@
  * 2. Target specific elements and write your own CSS. A future change in HTML may break your style.
  * 3. (Coming soon...) Write your own template with Template Extensibility API.
  */
+
+/** RESETS */
+
+* {
+  box-sizing: border-box;
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/** GENERIC */
 html {
   font-size: var(--font-size-scaler);
 }
@@ -105,91 +114,7 @@ body {
   display: grid;
 }
 
-* {
-  box-sizing: border-box;
-}
-
-:not(:focus-visible) {
-  outline: none;
-}
-
-.card {
-  display: grid;
-  padding: 16px;
-  border-radius: var(--card-radius);
-  box-shadow: var(--card-shadow);
-  background: var(--card-bg);
-  border: 1px solid var(--card-border-color);
-}
-
-.z-stack {
-  display: grid;
-}
-.z-stack__layer {
-  grid-area: 1/1/-1/-1;
-}
-
-.sources {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: var(--card-stack-gap);
-}
-
-.daily-heading {
-  font-size: var(--font-size-L);
-  font-weight: 700;
-  margin: 0 0 4px 0;
-  padding-left: 16px;
-}
-
-.daily-heading__toggle {
-  font: inherit;
-  border: none;
-  background: none;
-  padding: 0;
-  text-align: start;
-  cursor: pointer;
-  color: var(--daily-heading-color);
-}
-.daily-heading__toggle:hover {
-  color: var(--daily-heading-hover-color);
-}
-
-.source-heading {
-  display: flex;
-  gap: 16px;
-  flex-wrap: wrap;
-  font-size: var(--font-size-s);
-  margin: 0 0 8px 0;
-  padding-right: var(--accordion-rail-indent);
-}
-.source-heading__name {
-  font: inherit;
-  font-size: var(--font-size-s);
-  font-weight: 600;
-  text-align: start;
-  border: none;
-  background: none;
-  padding: 0;
-  cursor: pointer;
-  color: var(--source-name-color);
-  flex-grow: 1;
-}
-.source-heading__name:hover {
-  color: var(--source-name-hover-color);
-}
-.source-heading__link {
-  color: var(--source-link-color);
-  font-weight: 400;
-  text-decoration: none;
-}
-.source-heading__link:hover {
-  color: var(--source-link-hover-color);
-  text-decoration: underline;
-}
-
+/** COMPONENTS */
 .article-expander {
   padding: 4px 0 4px 4px;
 }
@@ -200,16 +125,36 @@ body {
   line-height: var(--heading-line-height);
   font-weight: 600;
   user-select: none;
-}
-.article-expander__title:hover {
+  display: -webkit-box;
   cursor: pointer;
-  color: var(--article-title-hover-color);
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
-.article-expander__title::marker {
-  color: var(--accordion-title-marker-color);
+.article-expander[open] .article-expander__title {
+  display: block;
+  color: var(--article-title-expanded-color);
 }
-.article-expander__title:hover::marker {
-  color: var(--accordion-title-hover-marker-color);
+.article-expander__title::before {
+  content: "•";
+  color: var(--accordion-marker-color);
+  display: inline-flex;
+  justify-content: center;
+  width: 16px;
+  font-weight: 700;
+  margin-right: 8px;
+  font-family: monospace;
+}
+.article-expander[open] .article-expander__title::before {
+  color: var(--accordion-marker-expanded-color);
+}
+.article-expander .article-expander__title:hover::before {
+  content: "+";
+  color: var(--accordion-marker-hover-color);
+}
+.article-expander[open] .article-expander__title:hover::before {
+  content: "-";
+  color: var(--accordion-marker-hover-color);
 }
 
 .article-image {
@@ -222,29 +167,6 @@ body {
   display: block;
 }
 
-.media-object {
-  display: grid;
-  gap: 16px;
-}
-.media-object__media {
-  aspect-ratio: 16/9;
-  object-fit: cover;
-  width: 100%;
-}
-
-@media screen and (min-width: 40rem) {
-  .media-object {
-    grid-template: "text media" auto / 1fr auto;
-  }
-  .media-object__text {
-    grid-area: text;
-  }
-  .media-object__media {
-    height: 100px;
-    grid-area: media;
-    margin-bottom: var(--article-stack-gap);
-  }
-}
 .article-summary-link {
   color: var(--article-summary-color);
   font-size: var(--font-size-m);
@@ -271,10 +193,38 @@ body {
 
 .article-reading-time {
   font-weight: 400;
-  padding-left: 8px;
   color: var(--article-reading-time-color);
   font-size: var(--font-size-s);
   white-space: nowrap;
+}
+
+.card {
+  display: grid;
+  padding: 16px;
+  border-radius: var(--card-radius);
+  box-shadow: var(--card-shadow);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border-color);
+}
+
+.daily-heading {
+  font-size: var(--font-size-L);
+  font-weight: 700;
+  margin: 0 0 4px 0;
+  padding-left: 16px;
+}
+
+.daily-heading__toggle {
+  font: inherit;
+  border: none;
+  background: none;
+  padding: 0;
+  text-align: start;
+  cursor: pointer;
+  color: var(--daily-heading-color);
+}
+.daily-heading__toggle:hover {
+  color: var(--daily-heading-hover-color);
 }
 
 footer {
@@ -293,4 +243,76 @@ footer {
 .footer-link:hover {
   color: var(--footer-link-hover-color);
   text-decoration: underline;
+}
+
+.media-object {
+  display: grid;
+  gap: 16px;
+}
+.media-object__media {
+  aspect-ratio: 16/9;
+  object-fit: cover;
+  width: 100%;
+}
+
+@media screen and (min-width: 40rem) {
+  .media-object {
+    grid-template: "text media" auto / 1fr auto;
+  }
+  .media-object__text {
+    grid-area: text;
+  }
+  .media-object__media {
+    height: 100px;
+    grid-area: media;
+    margin-bottom: var(--article-stack-gap);
+  }
+}
+
+.sources {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--card-stack-gap);
+}
+
+.source-heading {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-size: var(--font-size-s);
+  margin: 0 0 8px 0;
+  padding-right: var(--accordion-rail-indent);
+}
+.source-heading__name {
+  font: inherit;
+  font-size: var(--font-size-s);
+  font-weight: 400;
+  text-align: start;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--source-name-color);
+  flex-grow: 1;
+}
+.source-heading__name:hover {
+  color: var(--source-name-hover-color);
+}
+.source-heading__link {
+  color: var(--source-link-color);
+  font-weight: 400;
+  text-decoration: none;
+}
+.source-heading__link:hover {
+  color: var(--source-link-hover-color);
+  text-decoration: underline;
+}
+
+.z-stack {
+  display: grid;
+}
+.z-stack__layer {
+  grid-area: 1/1/-1/-1;
 }

--- a/packages/cli/src/system-static/index.css
+++ b/packages/cli/src/system-static/index.css
@@ -26,12 +26,12 @@
    */
   --font-family-default: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,
     "Helvetica Neue", sans-serif;
-  --font-size-scaler: 62.5%; /* 1rem = 10px */
   --font-size-L: 3.6rem;
   --font-size-m: 2.2rem;
   --font-size-s: 1.8rem;
-  --body-line-height: 1.4;
-  --heading-line-height: 1.2;
+  --font-size-scaler: 62.5%; /* 1rem = 10px */
+  --line-height-body: 1.4;
+  --line-height-heading: 1.2;
 
   /**
    * Components
@@ -41,28 +41,29 @@
   --body-padding: 32px 24px;
   --body-stack-gap: 32px;
 
-  --accordion-content-rail-color: var(--base03);
   --accordion-content-hover-rail-color: var(--base04);
+  --accordion-content-rail-color: var(--base03);
   --accordion-marker-color: var(--base0E);
-  --accordion-marker-hover-color: var(--base0E);
   --accordion-marker-expanded-color: var(--base03);
+  --accordion-marker-hover-color: var(--base0E);
   --accordion-rail-indent: 7px;
 
+  --article-image-border-color: var(--base03);
+  --article-image-radius: 6px;
+  --article-image-shadow: none;
+  --article-reading-time-color: var(--base04);
   --article-stack-gap: 16px;
-  --article-title-color: var(--base0E);
-  --article-title-expanded-color: var(--base0E);
   --article-summary-color: var(--base05);
   --article-summary-hover-color: var(--base07);
-  --article-reading-time-color: var(--base04);
-  --article-image-radius: 6px;
-  --article-image-border-color: var(--base03);
-  --article-image-shadow: none;
+  --article-title-color: var(--base0E);
+  --article-title-expanded-color: var(--base0E);
 
-  --card-border-color: var(--base03);
   --card-bg: var(--base01);
+  --card-border-color: var(--base03);
+  --card-padding: 16px;
   --card-radius: 8px;
-  --card-stack-gap: 24px;
   --card-shadow: none;
+  --card-stack-gap: 24px;
 
   --daily-heading-color: var(--base03);
   --daily-heading-hover-color: var(--base04);
@@ -70,10 +71,10 @@
   --footer-color: var(--base04);
   --footer-link-hover-color: var(--base07);
 
-  --source-name-color: var(--base0A);
-  --source-name-hover-color: var(--base07);
   --source-link-color: var(--base04);
   --source-link-hover-color: var(--base07);
+  --source-name-color: var(--base0A);
+  --source-name-hover-color: var(--base07);
 }
 
 /**
@@ -106,7 +107,7 @@ html {
 body {
   background-color: var(--body-bg);
   font-family: var(--font-family-default);
-  line-height: var(--body-line-height);
+  line-height: var(--line-height-body);
   color: var(--body-color);
   margin: 0;
   gap: var(--body-stack-gap);
@@ -122,7 +123,7 @@ body {
 .article-expander__title {
   color: var(--article-title-color);
   font-size: var(--font-size-m);
-  line-height: var(--heading-line-height);
+  line-height: var(--line-height-heading);
   font-weight: 600;
   user-select: none;
   display: -webkit-box;
@@ -154,7 +155,7 @@ body {
 }
 .article-expander[open] .article-expander__title:hover::before {
   content: "-";
-  color: var(--accordion-marker-hover-color);
+  color: var(--accordion-marker-expanded-hover-color);
 }
 
 .article-image {
@@ -199,32 +200,44 @@ body {
 }
 
 .card {
-  display: grid;
-  padding: 16px;
   border-radius: var(--card-radius);
   box-shadow: var(--card-shadow);
-  background: var(--card-bg);
+  background: var(--card-border-color);
   border: 1px solid var(--card-border-color);
+  overflow: hidden;
+}
+
+.card__section {
+  display: grid;
+  padding: var(--card-padding);
+  background: var(--card-bg);
 }
 
 .daily-heading {
+  display: grid;
   font-size: var(--font-size-L);
   font-weight: 700;
   margin: 0 0 4px 0;
-  padding-left: 16px;
 }
 
-.daily-heading__toggle {
+.daily-heading-toggle {
   font: inherit;
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 16px;
   border: none;
   background: none;
-  padding: 0;
+  padding: 0 var(--card-padding);
   text-align: start;
   cursor: pointer;
   color: var(--daily-heading-color);
 }
-.daily-heading__toggle:hover {
+.daily-heading-toggle:hover {
   color: var(--daily-heading-hover-color);
+}
+.daily-heading-toggle__date {
+  font-size: var(--font-size-m);
 }
 
 footer {
@@ -274,7 +287,7 @@ footer {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: var(--card-stack-gap);
+  gap: 1px;
 }
 
 .source-heading {

--- a/packages/cli/src/system-static/index.css
+++ b/packages/cli/src/system-static/index.css
@@ -27,9 +27,9 @@
   --font-family-default: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell,
     "Helvetica Neue", sans-serif;
   --font-size-scaler: 62.5%; /* 1rem = 10px */
-  --font-size-L: 3.2rem;
-  --font-size-m: 2.4rem;
-  --font-size-s: 1.8rem;
+  --font-size-L: 3.6rem;
+  --font-size-m: 2.2rem;
+  --font-size-s: 1.6rem;
   --body-line-height: 1.4;
   --heading-line-height: 1.2;
 
@@ -38,7 +38,8 @@
    */
   --body-color: var(--base04);
   --body-bg: var(--base00);
-  --body-padding: 24px;
+  --body-padding: 32px 24px;
+  --body-stack-gap: 32px;
 
   --daily-heading-color: var(--base03);
   --daily-heading-hover-color: var(--base04);
@@ -99,7 +100,7 @@ body {
   line-height: var(--body-line-height);
   color: var(--body-color);
   margin: 0;
-  gap: 24px;
+  gap: var(--body-stack-gap);
   padding: var(--body-padding);
   display: grid;
 }
@@ -148,6 +149,7 @@ body {
   border: none;
   background: none;
   padding: 0;
+  text-align: start;
   cursor: pointer;
   color: var(--daily-heading-color);
 }

--- a/packages/cli/src/system-static/index.css
+++ b/packages/cli/src/system-static/index.css
@@ -45,6 +45,8 @@
 
   --source-name-color: var(--base05);
   --source-name-hover-color: var(--base07);
+  --source-link-color: var(--base04);
+  --source-link-hover-color: var(--base07);
 
   --article-stack-gap: 16px;
 
@@ -64,6 +66,7 @@
   --accordion-content-hover-rail-color: var(--base04);
   --accordion-title-marker-color: var(--base03);
   --accordion-title-hover-marker-color: var(--base04);
+  --accordion-rail-indent: 7px;
 
   --card-border-color: var(--base03);
   --card-bg: var(--base01);
@@ -101,16 +104,28 @@ body {
   display: grid;
 }
 
+* {
+  box-sizing: border-box;
+}
+
 :not(:focus-visible) {
   outline: none;
 }
 
 .card {
+  display: grid;
   padding: 16px;
   border-radius: var(--card-radius);
   box-shadow: var(--card-shadow);
   background: var(--card-bg);
   border: 1px solid var(--card-border-color);
+}
+
+.z-stack {
+  display: grid;
+}
+.z-stack__layer {
+  grid-area: 1/1/-1/-1;
 }
 
 .sources {
@@ -140,26 +155,41 @@ body {
   color: var(--daily-heading-hover-color);
 }
 
-.source {
-  display: grid;
+.source-heading {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-size: var(--font-size-s);
+  margin: 0 0 8px 0;
+  padding-right: var(--accordion-rail-indent);
 }
-
-.source-name {
+.source-heading__name {
+  font: inherit;
   font-size: var(--font-size-s);
   font-weight: 600;
-  margin: 0 0 8px 0;
-}
-.source-name__link {
+  text-align: start;
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
   color: var(--source-name-color);
+  flex-grow: 1;
+}
+.source-heading__name:hover {
+  color: var(--source-name-hover-color);
+}
+.source-heading__link {
+  color: var(--source-link-color);
+  font-weight: 400;
   text-decoration: none;
 }
-.source-name__link:hover {
-  color: var(--source-name-hover-color);
+.source-heading__link:hover {
+  color: var(--source-link-hover-color);
   text-decoration: underline;
 }
 
 .article-expander {
-  padding: 4px;
+  padding: 4px 0 4px 4px;
 }
 
 .article-expander__title {
@@ -182,9 +212,7 @@ body {
 
 .article-image {
   display: none;
-  aspect-ratio: 16/9;
   border-radius: var(--article-image-radius);
-  object-fit: cover;
   border: 1px solid var(--article-image-border-color);
   box-shadow: var(--article-image-shadow);
 }
@@ -194,23 +222,20 @@ body {
 
 .media-object {
   display: grid;
-  grid-template:
-    "media" auto
-    "text" auto / 1fr;
   gap: 16px;
 }
-.media-object__text {
-  grid-area: text;
-}
 .media-object__media {
-  grid-area: media;
-
+  aspect-ratio: 16/9;
+  object-fit: cover;
   width: 100%;
 }
 
 @media screen and (min-width: 40rem) {
   .media-object {
     grid-template: "text media" auto / 1fr auto;
+  }
+  .media-object__text {
+    grid-area: text;
   }
   .media-object__media {
     height: 100px;
@@ -231,7 +256,7 @@ body {
 
 .article-summary-box-outer {
   display: block;
-  padding: 6px 7px var(--article-stack-gap) 7px;
+  padding: 6px var(--accordion-rail-indent) var(--article-stack-gap) var(--accordion-rail-indent);
 }
 
 .article-summary-box-inner {
@@ -239,6 +264,7 @@ body {
   border-left: 1px solid var(--accordion-content-rail-color);
   font-size: var(--font-size-s);
   overflow-wrap: anywhere;
+  word-break: break-word; /* same as above, for Safari compatitiliby */
 }
 
 .article-reading-time {

--- a/packages/cli/src/system-static/index.css
+++ b/packages/cli/src/system-static/index.css
@@ -68,8 +68,8 @@
   --daily-heading-color: var(--base03);
   --daily-heading-hover-color: var(--base04);
 
-  --footer-color: var(--base04);
-  --footer-link-hover-color: var(--base07);
+  --footer-color: var(--base03);
+  --footer-link-hover-color: var(--base04);
 
   --source-link-color: var(--base04);
   --source-link-hover-color: var(--base07);

--- a/packages/cli/src/system-static/index.js
+++ b/packages/cli/src/system-static/index.js
@@ -1,27 +1,87 @@
-// Render build timestamp
-const timestamp = document.getElementById("build-timestamp");
-timestamp.innerText = new Date(timestamp.getAttribute("datetime")).toLocaleString();
-
-// Handle input events
-document.addEventListener("click", (event) => {
-  // Activate daily title as expanders
-  const action = event.target.closest("[data-action]");
-  if (action) {
-    switch (action.getAttribute("data-action")) {
-      case "toggle-accordions":
-        handleToggleDailyExpand(event);
-        break;
-    }
-  }
-});
+closeAccordionByIds(getClosedAccordionIdsFromStorage());
+handleAllClickEvents();
+renderBuildTimestamp();
 
 /**
- * @param {KeyboardEvent} event
+ * ====== UTILS ======
+ **/
+
+function getClosedAccordionIdsFromPage() {
+  /**
+   * @type {HTMLDetailsElement[]}
+   */
+  const accordions = [...document.querySelectorAll("[data-accordion-key]")];
+  const ids = accordions
+    .filter((element) => !element.open)
+    .map((element) => element.getAttribute("data-accordion-key"));
+  return [...new Set(ids)];
+}
+
+function closeAccordionByIds(ids) {
+  ids.forEach((id) => {
+    const element = document.querySelector(`[data-accordion-key="${id}"]`);
+    if (element) element.open = false;
+  });
+}
+
+function storeClosedAccordionIds(ids) {
+  localStorage.setItem("closedAccordionIds", JSON.stringify(ids));
+}
+
+function getClosedAccordionIdsFromStorage() {
+  const stateString = localStorage.getItem("closedAccordionIds");
+  try {
+    return JSON.parse(stateString);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Add a few event handlers as possible to ensure healthy performance scaling
  */
-function handleToggleDailyExpand(event) {
+function handleAllClickEvents() {
+  document.addEventListener("click", (event) => {
+    // Activate daily title as expanders
+    const action = event.target.closest("[data-action]");
+    if (action) {
+      switch (action.getAttribute("data-action")) {
+        case "toggle-accordions":
+          handleToggleAccordions(event);
+          break;
+        case "toggle-native-accordion":
+          handleToggleNativeAccordion(event);
+          break;
+      }
+    }
+  });
+}
+
+/**
+ * @param {KeyboardEvent=} event
+ */
+function handleToggleAccordions(event) {
   // when ctrl is held, toggle every accordion in the document
-  const scope = event.ctrlKey ? document : event.target.closest(".js-toggle-accordions-scope");
+  const scope = event?.ctrlKey ? document : event.target.closest(".js-toggle-accordions-scope");
   const detailsElements = [...scope.querySelectorAll("details")];
   const isAnyOpen = detailsElements.some((element) => element.open);
   detailsElements.forEach((element) => (element.open = !isAnyOpen));
+
+  storeClosedAccordionIds(getClosedAccordionIdsFromPage());
+}
+
+/**
+ * @param {KeyboardEvent=} event
+ */
+function handleToggleNativeAccordion() {
+  // wait until event settled
+  setTimeout(() => storeClosedAccordionIds(getClosedAccordionIdsFromPage()), 0);
+}
+
+/**
+ * Convert machine readable timestamp to locale time
+ */
+function renderBuildTimestamp() {
+  const timestamp = document.getElementById("build-timestamp");
+  timestamp.innerText = new Date(timestamp.getAttribute("datetime")).toLocaleString();
 }

--- a/packages/cli/src/system-static/index.js
+++ b/packages/cli/src/system-static/index.js
@@ -89,4 +89,25 @@ function renderBuildTimestamp() {
   timestamp.innerText = new Date(timestamp.getAttribute("datetime")).toLocaleString();
 }
 
-function renderWeekday() {}
+/**
+ * Convert the server timestamp to human readable weekday and dates.
+ * Note: the server is responsible for shifting the date based on config file.
+ * The client should parse the date as if it is in UTC timezone.
+ */
+function renderWeekday() {
+  document.querySelectorAll(".js-offset-weekday").forEach((element) => {
+    const weekday = new Date(element.getAttribute("data-offset-date")).toLocaleString(window.navigator.language, {
+      weekday: "long",
+      timeZone: "UTC",
+    });
+    element.innerText = weekday;
+  });
+  document.querySelectorAll(".js-offset-date").forEach((element) => {
+    const date = new Date(element.getAttribute("data-offset-date")).toLocaleString(window.navigator.language, {
+      month: "numeric",
+      day: "numeric",
+      timeZone: "UTC",
+    });
+    element.innerText = date;
+  });
+}

--- a/packages/cli/src/system-static/index.js
+++ b/packages/cli/src/system-static/index.js
@@ -1,6 +1,7 @@
 closeAccordionByIds(getClosedAccordionIdsFromStorage());
 handleAllClickEvents();
 renderBuildTimestamp();
+renderWeekday();
 
 /**
  * ====== UTILS ======
@@ -31,7 +32,9 @@ function storeClosedAccordionIds(ids) {
 function getClosedAccordionIdsFromStorage() {
   const stateString = localStorage.getItem("closedAccordionIds");
   try {
-    return JSON.parse(stateString);
+    const parsed = JSON.parse(stateString);
+    if (!parsed?.length) return [];
+    return parsed;
   } catch {
     return [];
   }
@@ -85,3 +88,5 @@ function renderBuildTimestamp() {
   const timestamp = document.getElementById("build-timestamp");
   timestamp.innerText = new Date(timestamp.getAttribute("datetime")).toLocaleString();
 }
+
+function renderWeekday() {}

--- a/packages/cli/src/system-templates/index.hbs
+++ b/packages/cli/src/system-templates/index.hbs
@@ -19,17 +19,18 @@
       <section class="daily-content js-toggle-accordions-scope">
         <h2 class="daily-heading">
           <button
-            class="daily-heading__toggle"
+            class="daily-heading-toggle"
             data-action="toggle-accordions"
             title="Click to toggle the day, Ctrl + click to toggle all."
           >
-            <time class="js-weekday" datetime="{{isoLatestPublishTime}}">{{isoPublishDate}}</time>
+            <time class="daily-heading-toggle__weekday js-offset-weekday" data-offset-date={{isoOffsetPublishDate}} datetime="{{isoUtcPublishTime}}">{{isoOffsetPublishDate}}</time>
+            <time class="daily-heading-toggle__date js-offset-date" data-offset-date={{isoOffsetPublishDate}} datetime="{{isoUtcPublishTime}}"></time>
           </button>
         </h2>
-        <ul class="sources">
+        <ul class="sources card">
           {{#each sources}}
-            <li>
-              <section class="card js-toggle-accordions-scope">
+            <li class="card__section">
+              <section class="js-toggle-accordions-scope">
                 <h3 class="source-heading">
                   <button
                     class="source-heading__name"

--- a/packages/cli/src/system-templates/index.hbs
+++ b/packages/cli/src/system-templates/index.hbs
@@ -18,32 +18,48 @@
     {{#each dates}}
       <section class="daily-content js-toggle-accordions-scope">
         <h2 class="daily-heading">
-          <button class="daily-heading__toggle" data-action="toggle-accordions" title="Click to toggle the day, Ctrl + click to toggle all."><time
-              datetime="{{isoPublishDate}}"
-            >{{isoPublishDate}}</time></button>
+          <button
+            class="daily-heading__toggle"
+            data-action="toggle-accordions"
+            title="Click to toggle the day, Ctrl + click to toggle all."
+          >
+            <time class="js-weekday" datetime="{{isoLatestPublishTime}}">{{isoPublishDate}}</time>
+          </button>
         </h2>
         <ul class="sources">
           {{#each sources}}
             <li>
               <section class="card js-toggle-accordions-scope">
                 <h3 class="source-heading">
-                  <button class="source-heading__name" data-action="toggle-accordions" title="Click to toggle the source, Ctrl + click to toggle all.">{{title}}</button>
+                  <button
+                    class="source-heading__name"
+                    data-action="toggle-accordions"
+                    title="Click to toggle the source, Ctrl + click to toggle all."
+                  >{{title}}</button>
                   <a class="source-heading__link" href="{{siteUrl}}">Open</a>
                 </h3>
                 <section class="articles-per-source">
                   {{#each articles}}
                     <article>
-                      <details class="article-expander" data-action="toggle-native-accordion" data-accordion-key="{{id}}" open>
-                        <summary class="article-expander__title">
-                          <span>{{title}}</span>
-                          <span class="article-reading-time">{{readingTimeInMin}} min</span>
-                        </summary>
+                      <details
+                        class="article-expander"
+                        data-action="toggle-native-accordion"
+                        data-accordion-key="{{id}}"
+                        open
+                      >
+                        <summary class="article-expander__title">{{title}}</summary>
                         <a class="article-summary-link article-summary-box-outer" href="{{link}}">
                           <div class="article-summary-box-inner media-object">
                             {{#if imageUrl}}
                               <img src="{{imageUrl}}" loading="lazy" class="media-object__media article-image" />
                             {{/if}}
-                            <span class="media-object__text">{{description}}</span>
+                            <span class="media-object__text">
+                              <span>{{description}}</span>
+                              {{#if readingTimeInMin}}
+                                &ensp;<span class="article-reading-time">(&hairsp;{{readingTimeInMin}}
+                                  min&hairsp;)</span>
+                              {{/if}}
+                            </span>
                           </div>
                         </a>
                       </details>

--- a/packages/cli/src/system-templates/index.hbs
+++ b/packages/cli/src/system-templates/index.hbs
@@ -1,62 +1,68 @@
 <!DOCTYPE html>
 <html lang="en">
 
-<head>
-  <title>{{siteTitle}}</title>
-  <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="robots" content="noindex, nofollow" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
-  <link rel="alternate" type="application/rss+xml" title="{{siteTitle}}" href="{{feedHref}}" />
-  <link href="index.css" rel="stylesheet" />
-  <!-- %before-head-end.html% -->
-</head>
+  <head>
+    <title>{{siteTitle}}</title>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="robots" content="noindex, nofollow" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="alternate" type="application/rss+xml" title="{{siteTitle}}" href="{{feedHref}}" />
+    <link href="index.css" rel="stylesheet" />
+    <!-- %before-head-end.html% -->
+  </head>
 
-<body>
-<!-- %after-body-begin.html% -->
-  {{#each dates}}
-  <section class="daily-content js-toggle-accordions-scope">
-    <h2 class="daily-heading">
-      <button class="daily-heading__toggle" data-action="toggle-accordions"><time datetime="{{isoPublishDate}}">{{isoPublishDate}}</time></button>
-    </h2>
-    <ul class="sources">
-      {{#each sources}}
-      <li class="source card">
-        <section>
-          <h3 class="source-name"><a class="source-name__link" href="{{siteUrl}}">{{title}}</a></h3>
-          <section class="articles-per-source">
-            {{#each articles}}
-            <article>
-              <details class="article-expander" open>
-                <summary class="article-expander__title">
-                    <span>{{title}}</span>
-                    <span class="article-reading-time">{{readingTimeInMin}} min</span>
-                </summary>
-                <a class="article-summary-link article-summary-box-outer" href="{{link}}">
-                  <div class="article-summary-box-inner media-object">
-                    {{#if imageUrl}}
-                    <img src="{{imageUrl}}" loading="lazy" class="media-object__media article-image"/>
-                    {{/if}}
-                    <span class="media-object__text">{{description}}</span>
-                  </div>
-                </a>
-              </details>
-            </article>
-            {{/each}}
-        </section>
-      </li>
-      {{/each}}
-    </ul>
-  </section>
-  {{/each}}
+  <body>
+    <!-- %after-body-begin.html% -->
+    {{#each dates}}
+      <section class="daily-content js-toggle-accordions-scope">
+        <h2 class="daily-heading">
+          <button class="daily-heading__toggle" data-action="toggle-accordions" title="Click to toggle the day, Ctrl + click to toggle all."><time
+              datetime="{{isoPublishDate}}"
+            >{{isoPublishDate}}</time></button>
+        </h2>
+        <ul class="sources">
+          {{#each sources}}
+            <li>
+              <section class="card js-toggle-accordions-scope">
+                <h3 class="source-heading">
+                  <button class="source-heading__name" data-action="toggle-accordions" title="Click to toggle the source, Ctrl + click to toggle all.">{{title}}</button>
+                  <a class="source-heading__link" href="{{siteUrl}}">Open</a>
+                </h3>
+                <section class="articles-per-source">
+                  {{#each articles}}
+                    <article>
+                      <details class="article-expander" data-action="toggle-native-accordion" data-accordion-key="{{id}}" open>
+                        <summary class="article-expander__title">
+                          <span>{{title}}</span>
+                          <span class="article-reading-time">{{readingTimeInMin}} min</span>
+                        </summary>
+                        <a class="article-summary-link article-summary-box-outer" href="{{link}}">
+                          <div class="article-summary-box-inner media-object">
+                            {{#if imageUrl}}
+                              <img src="{{imageUrl}}" loading="lazy" class="media-object__media article-image" />
+                            {{/if}}
+                            <span class="media-object__text">{{description}}</span>
+                          </div>
+                        </a>
+                      </details>
+                    </article>
+                  {{/each}}
+                </section>
+              </section>
+            </li>
+          {{/each}}
+        </ul>
+      </section>
+    {{/each}}
 
-  <footer>
-    <time id="build-timestamp" datetime="{{siteBuildTimestamp}}">{{siteBuildTimestamp}}</time>
-    <span><a class="footer-link" href="{{projectUrl}}">osmosfeed {{cliVersion}}</a></span>
-  </footer>
-  <script src="index.js"></script>
-  <!-- %before-body-end.html% -->
-</body>
+    <footer>
+      <time id="build-timestamp" datetime="{{siteBuildTimestamp}}">{{siteBuildTimestamp}}</time>
+      <span><a class="footer-link" href="{{projectUrl}}">osmosfeed {{cliVersion}}</a></span>
+    </footer>
+    <script src="index.js"></script>
+    <!-- %before-body-end.html% -->
+  </body>
 
 </html>

--- a/packages/cli/src/system-templates/index.hbs
+++ b/packages/cli/src/system-templates/index.hbs
@@ -75,8 +75,14 @@
     {{/each}}
 
     <footer>
+      {{#if githubRunUrl}}
+      <a class="footer-link" href="{{githubRunUrl}}">
+        <time id="build-timestamp" datetime="{{siteBuildTimestamp}}">{{siteBuildTimestamp}}</time>
+      </a>
+      {{else}}
       <time id="build-timestamp" datetime="{{siteBuildTimestamp}}">{{siteBuildTimestamp}}</time>
-      <span><a class="footer-link" href="{{projectUrl}}">osmosfeed {{cliVersion}}</a></span>
+      {{/if}}
+      <a class="footer-link" href="{{projectUrl}}">osmosfeed {{cliVersion}}</a>
     </footer>
     <script src="index.js"></script>
     <!-- %before-body-end.html% -->

--- a/packages/sandbox/osmosfeed.yaml
+++ b/packages/sandbox/osmosfeed.yaml
@@ -3,6 +3,9 @@
 # cacheUrl: https://dailyread.netlify.app/cache.json
 # cacheMaxDays: 30
 # siteTitle: dev - osmosfeed
+# timezone: Asia/Shanghai
+timezone: America/Los_Angeles
+# timezone: UTC
 sources:
   - href: https://www.freecodecamp.org/news/rss/
   - href: https://christianheilmann.com/feed/
@@ -11,7 +14,7 @@ sources:
   - href: https://developer.chrome.com/feeds/blog.xml
   - href: https://webkit.org/feed/atom/
   - href: https://hacks.mozilla.org/feed/
-  # - href: https://gomakethings.com/feed
-  # - href: https://feeds.npr.org/510289/podcast.xml
-  # - href: https://shoptalkshow.com/feed/podcast/
-  # - href: https://feed.syntax.fm/rss
+  - href: https://gomakethings.com/feed
+  - href: https://feeds.npr.org/510289/podcast.xml
+  - href: https://shoptalkshow.com/feed/podcast/
+  - href: https://feed.syntax.fm/rss

--- a/packages/sandbox/osmosfeed.yaml
+++ b/packages/sandbox/osmosfeed.yaml
@@ -3,9 +3,7 @@
 # cacheUrl: https://dailyread.netlify.app/cache.json
 # cacheMaxDays: 30
 # siteTitle: dev - osmosfeed
-# timezone: Asia/Shanghai
 timezone: America/Los_Angeles
-# timezone: UTC
 sources:
   - href: https://www.freecodecamp.org/news/rss/
   - href: https://christianheilmann.com/feed/


### PR DESCRIPTION
- New: Adjust article grouping based on timezone. You need to add `timezone` in `osmosfeed.yml` for accurate grouping. [See details in documentation](./docs/osmosfeed-yaml-reference.md).
- New: Card title now toggles card content
- New: all toggles on the UI are persisted with local storage. You can use it to track read/unread status within a single browser.
- New: Build timestamp now links to the GitHub Action run
- Changed: Sources are sorted based on publish time rather than alphabetical order
- Changed: Style adjusted for easier reading
- Fixed: Horizontal overflow on Safari
- Fixed: HTML syntax error in default template
